### PR TITLE
Only require dependencies that are referenced

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,11 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/framework-bundle": "~2.3"
+        "symfony/config": "^2.3",
+        "symfony/console": "^2.3",
+        "symfony/dependency-injection": "^2.3",
+        "symfony/http-kernel": "^2.3",
+        "psr/log": "^1.0.0"
     },
     "autoload": {
         "psr-4": { "Opale\\ConsoleExceptionBundle\\": "" }


### PR DESCRIPTION
When using the bundle in a standalone application, many things that are
not required at all are pulled. Requiring what is really needed only
will make it easier to work with this bundle.
